### PR TITLE
Update environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - requests
   - tqdm
   - pillow
+  - libsqlite <=3.48.0
   - pip:
     - onnxruntime
     - diskcache


### PR DESCRIPTION
libsqlite is constrained to version 3.48.0 or lower to fix 'Error: no such column: "size" - should this be a string literal in single-quotes?'